### PR TITLE
Migrate to 2.12.5 which is distroless Java 11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,24 +11,25 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 #
-FROM openzipkin/zipkin:2.12.1
-MAINTAINER OpenZipkin "http://zipkin.io/"
+
+FROM alpine
+
+WORKDIR /zipkin-gcp
 
 ENV ZIPKIN_GCP_REPO https://jcenter.bintray.com
 ENV ZIPKIN_GCP_VERSION 0.10.1
-# Readback is currently not supported
-ENV QUERY_ENABLED false
-# must match JRE, in this case zipkin:2.12.1 uses 1.8.0_191
-# see https://github.com/square/okhttp/blob/master/pom.xml for example mappings
-# this and the download of alpn-boot will be removed with https://github.com/openzipkin/docker-jre-full/issues/9
-ENV ALPN_VERSION 8.1.13.v20181017
 
-RUN apk add unzip && \ 
-  curl -SL $ZIPKIN_GCP_REPO/org/mortbay/jetty/alpn/alpn-boot/$ALPN_VERSION/alpn-boot-$ALPN_VERSION.jar > alpn-boot.jar && \
+RUN apk add curl unzip && \
   curl -SL $ZIPKIN_GCP_REPO/io/zipkin/gcp/zipkin-autoconfigure-storage-stackdriver/$ZIPKIN_GCP_VERSION/zipkin-autoconfigure-storage-stackdriver-$ZIPKIN_GCP_VERSION-module.jar > stackdriver.jar && \
   echo > .stackdriver_profile && \
   unzip stackdriver.jar -d stackdriver && \
-  rm stackdriver.jar && \
-  apk del unzip
+  rm stackdriver.jar
 
-CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; java ${JAVA_OPTS} -Dloader.path=stackdriver -Dspring.profiles.active=stackdriver -Xbootclasspath/p:alpn-boot.jar -cp . org.springframework.boot.loader.PropertiesLauncher
+FROM openzipkin/zipkin:2.12.5
+MAINTAINER OpenZipkin "http://zipkin.io/"
+
+ENV ZIPKIN_GCP_VERSION 0.10.1
+# Readback is currently not supported
+ENV QUERY_ENABLED false
+
+env JAVA_OPTS="-Dloader.path=stackdriver -Dspring.profiles.active=stackdriver ${JAVA_OPTS}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine
 WORKDIR /zipkin-gcp
 
 ENV ZIPKIN_GCP_REPO https://jcenter.bintray.com
-ENV ZIPKIN_GCP_VERSION 0.10.1
+ENV ZIPKIN_GCP_VERSION 0.10.3
 
 RUN apk add curl unzip && \
   curl -SL $ZIPKIN_GCP_REPO/io/zipkin/gcp/zipkin-autoconfigure-storage-stackdriver/$ZIPKIN_GCP_VERSION/zipkin-autoconfigure-storage-stackdriver-$ZIPKIN_GCP_VERSION-module.jar > stackdriver.jar && \
@@ -28,7 +28,8 @@ RUN apk add curl unzip && \
 FROM openzipkin/zipkin:2.12.5
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-ENV ZIPKIN_GCP_VERSION 0.10.1
+COPY --from=0 /zipkin-gcp/ /zipkin/
+
 # Readback is currently not supported
 ENV QUERY_ENABLED false
 


### PR DESCRIPTION
Also removed ALPN since it shouldn't be needed anymore (either because it's Java 11 or because I think we might be using boringssl now). Not sure if it would fail hard on startup before but at least it seems to start up with this configuration fine.