### PR TITLE
Switches from JAVA_OPTS to MODULE_OPTS for profile settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY --from=0 /zipkin-gcp/ /zipkin/
 # Readback is currently not supported
 ENV QUERY_ENABLED false
 
-env JAVA_OPTS="-Dloader.path=stackdriver -Dspring.profiles.active=stackdriver ${JAVA_OPTS}"
+env MODULE_OPTS="-Dloader.path=stackdriver -Dspring.profiles.active=stackdriver"


### PR DESCRIPTION
This avoids clobbering aws profile info when someone sets JAVA_OPTS

See https://github.com/openzipkin/docker-zipkin/pull/202